### PR TITLE
Use port 8080 instead of 9080

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker-compose up
 
 This will start Grafana and Prometheus containers and import the dashboard.
 
-Prometheus is configured to scrape metrics from Connector Runtime at http://localhost:9080/metrics.
+Prometheus is configured to scrape metrics from Connector Runtime at http://localhost:8080/actuator/prometheus.
 If you want to change the URL, update the [`prometheus.yml`](prometheus/prometheus.yml) file.
 
 ## Dashboard

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -23,4 +23,4 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     scrape_interval: 5s
     static_configs:
-    - targets: ['host.docker.internal:9080']
+    - targets: ['host.docker.internal:8080']


### PR DESCRIPTION
Connector runtime no longer uses port 9080 by default, it was replaced with 8080.